### PR TITLE
Change in package name

### DIFF
--- a/vmware-dvs/debian/changelog.in
+++ b/vmware-dvs/debian/changelog.in
@@ -1,10 +1,16 @@
-vmware-dvs (2:@VERSION@-@REVISION@) trusty; urgency=low
+networking-vsphere (3:@VERSION@-@REVISION@) trusty; urgency=low
+
+  * Update to Newton
+
+ -- Thomas Bachman <bachman@noironetworks.com>  Tue, 12 Sep 2017 19:07:00 +0000
+
+networking-vsphere (1.0.1-1) trusty; urgency=low
 
   * Update to Mitaka
 
  -- Thomas Bachman <bachman@noironetworks.com>  Thu, 13 Oct 2016 19:07:00 +0000
 
-vmware-dvs (@VERSION@-@REVISION@) trusty; urgency=low
+networking-vsphere (2015.3.0-1) trusty; urgency=low
 
   * [Placeholder]
 

--- a/vmware-dvs/debian/control
+++ b/vmware-dvs/debian/control
@@ -1,4 +1,4 @@
-Source: vmware-dvs
+Source: networking-vsphere
 Section: python
 Priority: optional
 Maintainer: Cisco Systems, Inc. <openstack-networking@cisco.com>
@@ -7,7 +7,7 @@ Standards-Version: 3.9.5
 Homepage: https://github.com/noironetworks/vmware-dvs
 Vcs-Browser: https://github.com/noironetworks/vmware-dvs
 
-Package: vmware-dvs
+Package: networking-vsphere
 Architecture: all
 Depends: ${misc:Depends}, python-novaclient, python-suds
 Description: Neutron agent for VMware DVS


### PR DESCRIPTION
This will be used to create a stable/newton branch for DVS agent packaging, while master will be used for stable/ocata.